### PR TITLE
index.html:change to relative path [skip ci]

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
     </div>
 		<h4>
 			<a href="index.html">Zetapack Techtree summary (home)</a> |
-			<a href="https://zetaglest.github.io/docs/">Game Help and Documentation</a>
+			<a href="/docs/">Game Help and Documentation</a>
 		</h4>
     <!-- end header -->
 


### PR DESCRIPTION
When running jekyll locally, this link would lead to the remove web site
instead of the local jekyll server.

That link is on all the html pages that are generated by
https://github.com/ZetaGlest/zetaglest.github.io/blob/master/convert_faction_xml2html/convert_faction_xml2html.pl

This patch just change the link on index.html, which is the page that's
loaded when jekyll is run.

The perl script script has been updated in
https://github.com/ZetaGlest/zetaglest.github.io/commit/b3f218d70ea7693d576f265172f68653240a55b2
but new html pages aren't generated yet due to bug #3